### PR TITLE
Test failures if a non-english locale is set

### DIFF
--- a/src/test/java/org/icatproject/utils/TestShellCommand.java
+++ b/src/test/java/org/icatproject/utils/TestShellCommand.java
@@ -88,7 +88,7 @@ public class TestShellCommand {
 		String stderr = sc.getStderr();
 		int exitCode = sc.getExitValue();
 		assertEquals("stdout", 0, stdout.length());
-		assertTrue("stderr", stderr.startsWith("date: invalid date"));
+		assertTrue("stderr", stderr.startsWith("date:"));
 		assertEquals("exitCode", 1, exitCode);
 	}
 
@@ -99,7 +99,7 @@ public class TestShellCommand {
 		String stderr = sc.getStderr();
 		int exitCode = sc.getExitValue();
 		assertEquals("stdout", 0, stdout.length());
-		assertTrue("stderr", stderr.startsWith("date: invalid date"));
+		assertTrue("stderr", stderr.startsWith("date:"));
 		assertEquals("exitCode", 1, exitCode);
 	}
 
@@ -110,8 +110,7 @@ public class TestShellCommand {
 		String stderr = sc.getStderr();
 		int exitCode = sc.getExitValue();
 		assertEquals("stdout", 0, stdout.length());
-		assertEquals("stderr", "Cannot run program \"wibble\": error=2, No such file or directory",
-				stderr);
+		assertTrue("stderr", stderr.startsWith("Cannot run program \"wibble\": error=2,"));
 		assertEquals("exitCode", 1, exitCode);
 	}
 


### PR DESCRIPTION
The test suite fails if a non-english locale is set.  For instance, if LANG is set to de_DE.UTF-8, testBadDate() and testBadDateFromList() fail because they expect stderr to start with `date: invalid date`, but get `date: ungültiges Datum`.  testWibble() fails because it expects `Cannot run program "wibble": error=2, No such file or directory` but gets `Cannot run program "wibble": error=2, Datei oder Verzeichnis nicht gefunden`.

This PR removes the locale sensitive bits from the expected error output in the tests.