### PR TITLE
Implement CI

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -3,6 +3,8 @@ on:
   workflow_dispatch:
   pull_request:
   push:
+    branches:
+      - master
 
 jobs:
   build_and_tests:

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,0 +1,24 @@
+name: CI Build
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+
+jobs:
+  build_and_tests:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        java: [ '8', '11' ]
+    steps:
+      - name: Setup Java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
+
+      - name: Checkout icat-utils
+        uses: actions/checkout@v2
+
+      - name: Run Build
+        run: mvn install -DskipTests

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -17,7 +17,14 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
 
-      - name: Checkout icat-utils
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Checkout authn-simple
         uses: actions/checkout@v2
 
       - name: Run Build

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -22,3 +22,6 @@ jobs:
 
       - name: Run Build
         run: mvn install -DskipTests
+
+      - name: Run Unit Tests
+        run: mvn test -B

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # icat-utils
+
+[![Build Status](https://github.com/icatproject/icat.utils/workflows/CI%20Build/badge.svg?branch=master)](https://github.com/icatproject/icat.utils/actions?query=workflow%3A%22CI+Build%22)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+# icat-utils


### PR DESCRIPTION
closes #17 

Implements CI and adds a status badge to the README. The status badge will start working once this PR gets merged in master, but this is the status badge for this branch to prove that it works:

[![Build Status](https://github.com/icatproject/icat.utils/workflows/CI%20Build/badge.svg?branch=implement-ci-%2317)](https://github.com/icatproject/authn.db/actions?query=workflow%3A%22CI+Build%22) 

- [ ] Java 8 CI should pass
- [ ] Java 11 CI should pass
- [ ] Should run maven build
- [ ] Should run unit tests