### PR TITLE
Use python3 instead of python

### DIFF
--- a/src/main/scripts/icatdoi
+++ b/src/main/scripts/icatdoi
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """A script for generating DataCite DOI's for ICAT Component
 releases. When given a major, minor and patch release number along
 with username and password credentials, it will build a DOI of the

--- a/src/main/scripts/setup-glassfish.py
+++ b/src/main/scripts/setup-glassfish.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 


### PR DESCRIPTION
Modern distros often don't have a `python` command, so use `python3` explicitly.