### PR TITLE
Improvements to AddressChecker

### DIFF
--- a/src/main/java/org/icatproject/utils/AddressChecker.java
+++ b/src/main/java/org/icatproject/utils/AddressChecker.java
@@ -51,11 +51,9 @@ public class AddressChecker {
 	}
 
 	private static BigInteger inetAddressToBigInteger(InetAddress inetAddress) {
-		BigInteger result = BigInteger.ZERO;
-		for (byte b : inetAddress.getAddress()) {
-			result = result.shiftLeft(8).add(BigInteger.valueOf(b & 0xff));
-		}
-		return result;
+		// Takes a byte array in big-endian order, so it is suitable for network addresses
+		// '1' indicates that a positive number should be returned
+		return new BigInteger(1, inetAddress.getAddress());
 	}
 
 	/**

--- a/src/main/java/org/icatproject/utils/AddressChecker.java
+++ b/src/main/java/org/icatproject/utils/AddressChecker.java
@@ -21,6 +21,7 @@ public class AddressChecker {
 			int inetAddressBits = patternAddress.getAddress().length * 8;
 
 			if (prefixLength == null) {
+				// Default to an exact match (/32 for IPv4, /128 for IPv6)
 				prefixLength = inetAddressBits;
 			}
 
@@ -28,6 +29,10 @@ public class AddressChecker {
 				throw new AddressCheckerException(String.format("Prefix length %d cannot be greater than %d for address %s", prefixLength, inetAddressBits, patternAddress.getHostAddress()));
 			}
 
+			/* Set the highest-order bits, e.g. for IPv4 with prefixLength=24:
+			 *  - bits 0-7 are set to 0
+			 *  - bits 8-31 are set to 1
+			 */
 			BigInteger mask = BigInteger.ZERO;
 			for (int i = 0; i < prefixLength; i++) {
 				mask = mask.setBit(inetAddressBits - i - 1);

--- a/src/test/java/org/icatproject/utils/TestAddressChecker.java
+++ b/src/test/java/org/icatproject/utils/TestAddressChecker.java
@@ -1,13 +1,14 @@
 package org.icatproject.utils;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
 public class TestAddressChecker {
 	@Test
-	public void t4() throws Exception {
+	public void testIpv4() throws AddressCheckerException {
 		AddressChecker a = new AddressChecker(" 192.168.3.0/24 190.168.3.0/28 ");
 		assertTrue("One", a.check("192.168.3.255"));
 		assertTrue("Two", a.check("190.168.3.15"));
@@ -16,10 +17,58 @@ public class TestAddressChecker {
 	}
 
 	@Test
-	public void t6() throws Exception {
+	public void testIpv6() throws AddressCheckerException{
 		AddressChecker a = new AddressChecker("192:168:3:0:0:0:0:0/112");
 		assertTrue("One", a.check("192:168:3:0:0:0:0:0"));
 		assertTrue("Two", a.check("192:168:3:0:0:0:0:FFFF"));
 		assertFalse("Three", a.check("192:168:3:0:0:0:1:0"));
+	}
+
+	@Test
+	public void testLocalhost() throws AddressCheckerException {
+		AddressChecker a = new AddressChecker("localhost");
+
+		assertTrue(a.check("127.0.0.1"));
+		assertFalse(a.check("127.0.0.0")); // flip last bit
+		assertFalse(a.check("255.0.0.1")); // flip first bit
+
+		assertTrue(a.check("::1"));
+		assertFalse(a.check("::0")); // flip last bit
+		assertFalse(a.check("8000::1")); // flip first bit
+	}
+
+	@Test
+	public void testInvalid() {
+		assertThrows(AddressCheckerException.class, () -> {
+			new AddressChecker("test.invalid");
+		});
+
+		assertThrows(AddressCheckerException.class, () -> {
+			new AddressChecker("localhost/32");
+		});
+
+		assertThrows(AddressCheckerException.class, () -> {
+			new AddressChecker("/");
+		});
+
+		assertThrows(AddressCheckerException.class, () -> {
+			new AddressChecker("/32");
+		});
+
+		assertThrows(AddressCheckerException.class, () -> {
+			new AddressChecker("10.0.0.0/");
+		});
+
+		assertThrows(AddressCheckerException.class, () -> {
+			new AddressChecker("10.0.0.0/-1");
+		});
+
+		assertThrows(AddressCheckerException.class, () -> {
+			new AddressChecker("10.0.0.0/x");
+		});
+
+		assertThrows(AddressCheckerException.class, () -> {
+			new AddressChecker("10.0.0.0/33");
+		});
 	}
 }


### PR DESCRIPTION
Refactor AddressChecker to make the following improvements to the pattern config:
 - Allows hostnames as well as IP addresses
 - The network prefix length is no longer mandatory, e.g. `127.0.0.1` can be used instead of `127.0.0.1/32`
 - Allows IPv6 address in shortened form, e.g. `::1` instead of `0:0:0:0:0:0:0:1`

The main motivation was so that `localhost` could be used (which matches both `127.0.0.1` and `::1`)